### PR TITLE
ci(claude): grant write to mention caller

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,6 +10,13 @@ on:
   pull_request_review:
     types: [submitted]
 
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  id-token: write
+  actions: read
+
 jobs:
   claude:
     uses: outcomeeng/gh-actions/.github/workflows/claude.yml@main


### PR DESCRIPTION
## Summary

The reusable `claude.yml` now declares `pull-requests: write` and `issues: write` at the job level so the action can post tracking and follow-up comments when `@claude` is mentioned. Update the caller to grant the same permissions; without this change the next mention run fails workflow validation with `called workflow asks for write but caller grants read`.

See [outcomeeng/gh-actions#cdb81e3](https://github.com/outcomeeng/gh-actions/commit/c77ce56) for the upstream change.

## Test plan

- [ ] PR triggers `Claude Code Review` (review path is unaffected; this only matters for `@claude` mentions)
- [ ] After merge, comment `@claude help` on a PR and confirm Claude posts a tracking comment